### PR TITLE
[#15] Validação dos dados do usuário quando respondendo uma questão

### DIFF
--- a/src/main/java/dev/drugowick/threehundredsixty/config/ValidationConfig.java
+++ b/src/main/java/dev/drugowick/threehundredsixty/config/ValidationConfig.java
@@ -1,0 +1,29 @@
+package dev.drugowick.threehundredsixty.config;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+@Configuration
+public class ValidationConfig {
+
+    /**
+     * This bean configures Spring's MessageSource as the default resource bundle, avoiding confusion with Hibernate's
+     * resource bundle (ValidationMessages.properties). One could use Hibernate's, but with this configuration that's
+     * not an option anymore. This is simpler and I prefer it.
+     *
+     * What this allows is to use a specific validation at the annotation above a domain class property, for example
+     * `@PositiveOrZero(message = "{message.specific.invalidNumber}")`, and create the `message.specific.invalidNumber`
+     * key on Spring's `message.properties` file.
+     *
+     * @param messageSource
+     * @return a {@link LocalValidatorFactoryBean} defining "message.properties" as default.
+     */
+    @Bean
+    LocalValidatorFactoryBean validator(MessageSource messageSource) {
+        LocalValidatorFactoryBean bean = new LocalValidatorFactoryBean();
+        bean.setValidationMessageSource(messageSource);
+        return bean;
+    }
+}

--- a/src/main/java/dev/drugowick/threehundredsixty/controller/FeedbackController.java
+++ b/src/main/java/dev/drugowick/threehundredsixty/controller/FeedbackController.java
@@ -1,16 +1,16 @@
 package dev.drugowick.threehundredsixty.controller;
 
 import dev.drugowick.threehundredsixty.domain.entity.Feedback;
-import dev.drugowick.threehundredsixty.domain.entity.FeedbackState;
 import dev.drugowick.threehundredsixty.domain.entity.Question;
 import dev.drugowick.threehundredsixty.domain.repository.FeedbackRepository;
 import dev.drugowick.threehundredsixty.domain.repository.QuestionRepository;
-import dev.drugowick.threehundredsixty.dto.AnswerDto;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 
-import javax.validation.Valid;
 import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
@@ -42,56 +42,5 @@ public class FeedbackController extends BaseController {
         }
         model.addAttribute("questions", questions);
         return "feedback-list-questions";
-    }
-
-    @GetMapping("/question/{questionId}")
-    public String getQuestion(Principal principal, Model model, @PathVariable Long evaluatedId, @PathVariable Long questionId) {
-
-        Optional<Question> optionalQuestion = questionRepository.findByEvaluatorEmailAndEvaluatedIdAndId(
-                principal.getName(),
-                evaluatedId,
-                questionId);
-        if (optionalQuestion.isPresent()) {
-            model.addAttribute("question", optionalQuestion.get());
-        } else {
-            throw new RuntimeException("Pergunta inexistente ou inválida para o usuário " + principal.getName());
-        }
-
-        optionalQuestion.ifPresent(question -> model.addAttribute("evaluation", question.getEvaluation()));
-
-        return "feedback-question";
-    }
-
-    @PostMapping("/question/{questionId}")
-    public String saveQuestion(Principal principal,
-                               Model model,
-                               @PathVariable Long evaluatedId,
-                               @PathVariable Long questionId,
-                               @Valid AnswerDto answerDto) {
-
-        Question question = questionRepository.getOne(questionId);
-        // TODO DTO transformation and Service stuff happening on the controller.
-        //  Should implement a proper mapping and analyze the need and architect a service layer.
-        question.setTitle(answerDto.getTitle());
-        question.setDescription(answerDto.getDescription());
-        question.setEvaluation(answerDto.getEvaluation());
-        question.setExample(answerDto.getExample());
-        question.setImprovement(answerDto.getImprovement());
-        questionRepository.save(question);
-
-        Optional<Feedback> optionalFeedback = feedbackRepository.findByEvaluatedIdAndEvaluatorEmail(evaluatedId, principal.getName());
-        optionalFeedback.ifPresent(feedback -> {
-            feedback.setState(FeedbackState.STARTED);
-            List<Question> feedbackQuestions = questionRepository.findAllByEvaluatorEmailAndEvaluatedId(principal.getName(), evaluatedId);
-            //TODO implement verification if feedback is finished.
-            if (feedbackQuestions
-                    .stream().parallel()
-                    .noneMatch(question1 -> question1.getEvaluation() == null || question1.getEvaluation().equals(""))) {
-                feedback.setState(FeedbackState.FINISHED);
-            }
-            feedbackRepository.save(feedback);
-        });
-
-        return "redirect:/feedback/" + evaluatedId;
     }
 }

--- a/src/main/java/dev/drugowick/threehundredsixty/controller/QuestionController.java
+++ b/src/main/java/dev/drugowick/threehundredsixty/controller/QuestionController.java
@@ -1,0 +1,109 @@
+package dev.drugowick.threehundredsixty.controller;
+
+import dev.drugowick.threehundredsixty.domain.entity.Feedback;
+import dev.drugowick.threehundredsixty.domain.entity.FeedbackState;
+import dev.drugowick.threehundredsixty.domain.entity.Question;
+import dev.drugowick.threehundredsixty.domain.repository.FeedbackRepository;
+import dev.drugowick.threehundredsixty.domain.repository.QuestionRepository;
+import dev.drugowick.threehundredsixty.dto.AnswerDto;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+
+@Controller
+@RequestMapping("/feedback/{evaluatedId}/question/{questionId}")
+public class QuestionController extends BaseController {
+
+    private QuestionRepository questionRepository;
+    private FeedbackRepository feedbackRepository;
+
+    public QuestionController(QuestionRepository questionRepository, FeedbackRepository feedbackRepository) {
+        this.questionRepository = questionRepository;
+        this.feedbackRepository = feedbackRepository;
+    }
+
+    @ModelAttribute("feedback")
+    public Feedback feedback(Principal principal, Model model, @PathVariable Long evaluatedId) {
+        Optional<Feedback> optionalFeedback = feedbackRepository.findByEvaluatedIdAndEvaluatorEmail(evaluatedId, principal.getName());
+        return optionalFeedback.orElseGet(Feedback::new);
+    }
+
+    @ModelAttribute("question")
+    public AnswerDto question(Principal principal, @PathVariable Long evaluatedId, @PathVariable Long questionId) {
+        Question question = questionRepository.findByEvaluatorEmailAndEvaluatedIdAndId(
+                principal.getName(),
+                evaluatedId,
+                questionId).orElse(null);
+
+        //TODO provide proper conversion strategy, not this "hardcoded" conversion
+        AnswerDto answerDto = new AnswerDto();
+        answerDto.setCategory(question.getCategory());
+        answerDto.setDescription(question.getDescription());
+        answerDto.setEvaluation(question.getEvaluation());
+        answerDto.setExample(question.getExample());
+        answerDto.setId(question.getId());
+        answerDto.setImprovement(question.getImprovement());
+        answerDto.setTitle(question.getTitle());
+
+        answerDto.setEvaluated(question.getEvaluated());
+        answerDto.setEvaluator(question.getEvaluator());
+
+        return answerDto;
+    }
+
+    @ModelAttribute("evaluation")
+    public String evaluation(Principal principal, @PathVariable Long evaluatedId, @PathVariable Long questionId) {
+        Question question = questionRepository.findByEvaluatorEmailAndEvaluatedIdAndId(
+                principal.getName(),
+                evaluatedId,
+                questionId).orElseThrow(RuntimeException::new);
+        return question.getEvaluation();
+    }
+
+    @GetMapping
+    public String getQuestion() {
+        return "feedback-question";
+    }
+
+    @PostMapping
+    public String saveQuestion(Principal principal,
+                               @PathVariable Long evaluatedId,
+                               @PathVariable Long questionId,
+                               @ModelAttribute("question") @Valid AnswerDto answerDto,
+                               BindingResult bindingResult) {
+
+        if (bindingResult.hasErrors()) {
+            return "feedback-question";
+        }
+        Question question = questionRepository.getOne(questionId);
+        // TODO DTO transformation and Service stuff happening on the controller.
+        //  Should implement a proper mapping and analyze the need and architect a service layer.
+        question.setTitle(answerDto.getTitle());
+        question.setDescription(answerDto.getDescription());
+        question.setEvaluation(answerDto.getEvaluation());
+        question.setExample(answerDto.getExample());
+        question.setImprovement(answerDto.getImprovement());
+        questionRepository.save(question);
+
+        Optional<Feedback> optionalFeedback = feedbackRepository.findByEvaluatedIdAndEvaluatorEmail(evaluatedId, principal.getName());
+        optionalFeedback.ifPresent(feedback -> {
+            feedback.setState(FeedbackState.STARTED);
+            List<Question> feedbackQuestions = questionRepository.findAllByEvaluatorEmailAndEvaluatedId(principal.getName(), evaluatedId);
+            //TODO implement verification if feedback is finished.
+            if (feedbackQuestions
+                    .stream().parallel()
+                    .noneMatch(question1 -> question1.getEvaluation() == null || question1.getEvaluation().equals(""))) {
+                feedback.setState(FeedbackState.FINISHED);
+            }
+            feedbackRepository.save(feedback);
+        });
+
+        return "redirect:/feedback/" + evaluatedId;
+    }
+}

--- a/src/main/java/dev/drugowick/threehundredsixty/controller/admin/EmployeeAdminController.java
+++ b/src/main/java/dev/drugowick/threehundredsixty/controller/admin/EmployeeAdminController.java
@@ -17,12 +17,12 @@ import java.util.Optional;
 
 @Controller
 @RequestMapping("/admin")
-public class EmployeeController extends BaseController {
+public class EmployeeAdminController extends BaseController {
 
     private final EmployeeRepository employeeRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public EmployeeController(EmployeeRepository employeeRepository, PasswordEncoder passwordEncoder) {
+    public EmployeeAdminController(EmployeeRepository employeeRepository, PasswordEncoder passwordEncoder) {
         this.employeeRepository = employeeRepository;
         this.passwordEncoder = passwordEncoder;
     }

--- a/src/main/java/dev/drugowick/threehundredsixty/controller/admin/QuestionAdminController.java
+++ b/src/main/java/dev/drugowick/threehundredsixty/controller/admin/QuestionAdminController.java
@@ -16,11 +16,11 @@ import java.util.Optional;
 
 @Controller
 @RequestMapping("/admin")
-public class QuestionController extends BaseController {
+public class QuestionAdminController extends BaseController {
 
     private final BaseQuestionRepository baseQuestionRepository;
 
-    public QuestionController(BaseQuestionRepository baseQuestionRepository) {
+    public QuestionAdminController(BaseQuestionRepository baseQuestionRepository) {
         this.baseQuestionRepository = baseQuestionRepository;
     }
 

--- a/src/main/java/dev/drugowick/threehundredsixty/dto/AnswerDto.java
+++ b/src/main/java/dev/drugowick/threehundredsixty/dto/AnswerDto.java
@@ -1,17 +1,42 @@
 package dev.drugowick.threehundredsixty.dto;
 
+import dev.drugowick.threehundredsixty.domain.entity.Employee;
+import dev.drugowick.threehundredsixty.validation.ImprovementNotBlankIfEvaluationIsNegative;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
+
+/**
+ * This class gets a custom annotation to ensure improvement is not blank when evaluation is negative.
+ */
 @Getter
 @Setter
+@ImprovementNotBlankIfEvaluationIsNegative(
+        fieldEvaluation = "evaluation",
+        fieldImprovement = "improvement",
+        negativeEvaluationValues = {"Não atende", "Atende parcialmente"},
+        message = "{message.custom.emptyImprovement}")
 public class AnswerDto {
     private Long id;
 
+    private Employee evaluator;
+    private Employee evaluated;
+
+    @NotBlank
+    private String category;
+
+    @NotBlank
     private String title;
+
+    @NotBlank
     private String description;
 
+    @NotBlank
     private String evaluation;
+
+    @NotBlank
     private String example;
+
     private String improvement;
 }

--- a/src/main/java/dev/drugowick/threehundredsixty/validation/ImprovementNotBlankIfEvaluationIsNegative.java
+++ b/src/main/java/dev/drugowick/threehundredsixty/validation/ImprovementNotBlankIfEvaluationIsNegative.java
@@ -1,0 +1,25 @@
+package dev.drugowick.threehundredsixty.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ TYPE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = { ImprovementNotBlankIfEvaluationIsNegativeValidator.class })
+public @interface ImprovementNotBlankIfEvaluationIsNegative {
+
+    String message() default "deve ser preenchido se avaliação é negativa";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+    String fieldEvaluation();
+    String fieldImprovement();
+    String[] negativeEvaluationValues();
+}

--- a/src/main/java/dev/drugowick/threehundredsixty/validation/ImprovementNotBlankIfEvaluationIsNegativeValidator.java
+++ b/src/main/java/dev/drugowick/threehundredsixty/validation/ImprovementNotBlankIfEvaluationIsNegativeValidator.java
@@ -1,0 +1,48 @@
+package dev.drugowick.threehundredsixty.validation;
+
+import org.springframework.beans.BeanUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ValidationException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
+
+public class ImprovementNotBlankIfEvaluationIsNegativeValidator implements ConstraintValidator<ImprovementNotBlankIfEvaluationIsNegative, Object> {
+
+    private String fieldEvaluation;
+    private String fieldImprovement;
+    private String[] negativeEvaluationValues;
+
+    @Override
+    public void initialize(ImprovementNotBlankIfEvaluationIsNegative constraintAnnotation) {
+        this.fieldEvaluation = constraintAnnotation.fieldEvaluation();
+        this.negativeEvaluationValues = constraintAnnotation.negativeEvaluationValues();
+        this.fieldImprovement = constraintAnnotation.fieldImprovement();
+    }
+
+    @Override
+    public boolean isValid(Object o, ConstraintValidatorContext constraintValidatorContext) {
+        boolean isValid = true;
+
+        try {
+            String improvement = (String) Objects.requireNonNull(BeanUtils.getPropertyDescriptor(o.getClass(), this.fieldImprovement))
+                    .getReadMethod().invoke(o);
+            if (improvement == null || improvement.trim().isEmpty()) {
+                String evaluation = (String) Objects.requireNonNull(BeanUtils.getPropertyDescriptor(o.getClass(), this.fieldEvaluation))
+                        .getReadMethod().invoke(o);
+                for (String negativeValue : negativeEvaluationValues) {
+                    if (evaluation.equals(negativeValue)) {
+                        isValid = false;
+                        break;
+                    }
+                }
+            }
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+            throw new ValidationException(e);
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,11 @@
+# Mensagem customizada para a anotações customizada.
+message.custom.emptyImprovement=Você precisa dar uma sugestão de melhoria quando a avaliação é negativa.
+
+# Mensagem traduzida para a validação NotBlank
+NotBlank={0} não pode ser vazio.
+
+# Nome do campo 'example' traduzido.
+example=Exemplo
+
+# Mensagem customizada mais específica para quando houver erro de validação NotBlank no campo Evaluation.
+NotBlank.evaluation=Use a lista de opções para selecionar uma avaliação para a questão.

--- a/src/main/resources/templates/feedback-question.html
+++ b/src/main/resources/templates/feedback-question.html
@@ -81,6 +81,12 @@
 
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 
+        <div th:if="${#fields.errors('*').size()}">
+            <div class="form-group alert alert-warning" th:each="err : ${#fields.errors('*')}">
+                <span th:text="${err}">Descrição de um erro</span>
+            </div>
+        </div>
+
         <div class="container-fluid text-left">
             <div class="float-md-none">
                 <button class=" btn btn-primary" type="submit">Salvar</button>


### PR DESCRIPTION
For that to work it was necessary to create a proper question controller with its own ModelAttributes. So all operations on Questions moved out from FeedbackController to the newly created QuestionController.
To the DTO (or Command Object) validations were added, including a custom one.
This custom validation is obviously also implemented on this commit.

Closes #15 