### PR TITLE
adds support to code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,63 @@
+# Orb 'circleci/maven@0.0.12' resolved to 'circleci/maven@0.0.12'
+version: 2
+jobs:
+  maven/test:
+##    Remember to set the 'CC_TEST_REPORTER_ID' environment variable to your proper value, in your CI provider!
+#
+    environment:
+      JACOCO_SOURCE_PATH: 'src/main/java'
+    docker:
+      - image: circleci/openjdk:13-jdk-buster
+    steps:
+      - checkout
+      - run:
+          name: Generate Cache Checksum
+          command: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
+      - restore_cache:
+          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+      - run:
+          name: Install Dependencies
+          command: mvn dependency:go-offline --settings 'pom.xml'
+      - run:
+          name: Code Climate Setup test-reporter
+          command: |
+            # download test reporter as a static binary
+                     curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+                     chmod +x ./cc-test-reporter
+#      - run:
+#          name: Run Maven Tests
+#          command: mvn verify --settings 'pom.xml'
+      - run:
+          name: Code Climate Run tests (coverage with Jacoco)
+          command: |
+            ./cc-test-reporter before-build
+            mvn verify --settings 'pom.xml'
+            ./cc-test-reporter \
+              format-coverage target/site/jacoco/jacoco.xml     \
+              --input-type jacoco
+            ./cc-test-reporter upload-coverage
+##           See: https://github.com/codeclimate/test-reporter/issues/259
+#            ./cc-test-reporter after-build --coverage-input-type jacoco --exit-code $?
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+      - store_test_results:
+          path: target/surefire-reports
+workflows:
+  maven_test:
+    jobs:
+      - maven/test
+  version: 2
+
+# Original config.yml file:
+# version: 2.1
+# 
+# orbs:
+#   maven: circleci/maven@0.0.12
+# 
+# workflows:
+#   maven_test:
+#     jobs:
+#       - maven/test # checkout, build, test, and upload test results

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,7 @@
+##
+# see:
+#	- https://www.rainerhahnekamp.com/en/ignoring-lombok-code-in-jacoco/
+#        - https://github.com/rainerhahnekamp/jacocolombok
+#	- https://medium.com/@mladen.bolic/lombok-data-improve-your-code-coverage-a74fb624a72b
+lombok.addLombokGeneratedAnnotation = true
+config.stopBubbling = true

--- a/pom.xml
+++ b/pom.xml
@@ -125,10 +125,91 @@
 
     <build>
         <plugins>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <jvmArguments>${argLine}</jvmArguments>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start-spring-boot</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-spring-boot</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+<!--						These lines guarantee spring itself is covered			-->
+<!--						(e.g. line `SpringApplication.run(....class, args);`) 	-->
+                        <id>default-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+
+<!--						Minimum requirements of code coverage: 		-->
+<!--						From:	https://www.baeldung.com/jacoco 	-->
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
@brunodrugowick , a gente nem conversou a respeito, mas como eu estava testando isso, resolvi por aqui :muscle: hahaha

### Geral
Esse PR adiciona o básico para ter code-coverage.
Isso por si só, não é tão útil, mas é bem legal para direcionar qual parte do código precisa ser coberta pelos testes (sejam integração ou unitário).

Por ser só o inicio está bem pequeno. Foi alterado:
* o `pom.xml`, claro; 
* criei o `lombok.config` pra fazer o Jacoco entender que sim, ele já estava rodando muito código do lombok (e calcular o valor correto, invés de sub-estimar); e 
* o `.circleci/config.yml`, para integrar com o CircleCI se quiser.

É bem fácil fazer o CircleCI conversar com o CodeClimate (só por a env-var) e então, nele, ver os percentuais e relatório de cobertura. Aí depois a gente poem uns badges no readme do projeto \o/

O que me chamou a atenção no CodeClimate é que ele dá umas métricas de debito-técnico, esforço pra entender o código e refatoração.

### Extra
Pra ver local roda um:

`mvn clean verify`

O report do Jacoco vai ter sido gerado em:

`target/site/jacoco/index.html`
