### PR TITLE
Tests for FeedbackController

### DIFF
--- a/src/main/java/dev/drugowick/threehundredsixty/controller/FeedbackController.java
+++ b/src/main/java/dev/drugowick/threehundredsixty/controller/FeedbackController.java
@@ -22,6 +22,8 @@ public class FeedbackController extends BaseController {
     private QuestionRepository questionRepository;
     private FeedbackRepository feedbackRepository;
 
+    protected String feedbackListQuestionTemplate = "feedback-list-questions";
+
     public FeedbackController(QuestionRepository questionRepository, FeedbackRepository feedbackRepository) {
         this.questionRepository = questionRepository;
         this.feedbackRepository = feedbackRepository;
@@ -41,6 +43,6 @@ public class FeedbackController extends BaseController {
             throw new RuntimeException("Feedback inexistente ou inválido para o usuário " + principal.getName());
         }
         model.addAttribute("questions", questions);
-        return "feedback-list-questions";
+        return feedbackListQuestionTemplate;
     }
 }

--- a/src/test/java/dev/drugowick/threehundredsixty/controller/FeedbackControllerIntegrationTest.java
+++ b/src/test/java/dev/drugowick/threehundredsixty/controller/FeedbackControllerIntegrationTest.java
@@ -1,0 +1,45 @@
+package dev.drugowick.threehundredsixty.controller;
+
+import dev.drugowick.threehundredsixty.service.MyUserDetailsService;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class FeedbackControllerIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MyUserDetailsService myUserDetailsService;
+
+    Long nonexistentFeedbackId = 9990009999L;
+    Long existentFeedbackId = 1L;
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password")
+    void whenGetNonExistentFeedback_thenFail() throws Exception {
+        mockMvc.perform(get("/feedback/" + nonexistentFeedbackId))
+                .andDo(print())
+                .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password")
+    void whenGetExistentFeedback_thenLoadPage() throws Exception {
+        mockMvc.perform(get("/feedback/" + existentFeedbackId))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/dev/drugowick/threehundredsixty/controller/FeedbackControllerUnitTest.java
+++ b/src/test/java/dev/drugowick/threehundredsixty/controller/FeedbackControllerUnitTest.java
@@ -1,0 +1,55 @@
+package dev.drugowick.threehundredsixty.controller;
+
+import dev.drugowick.threehundredsixty.service.MyUserDetailsService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.ui.Model;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class FeedbackControllerUnitTest {
+    @Mock
+    private Model model;
+
+    @Autowired
+    private MyUserDetailsService myUserDetailsService;
+
+    @Autowired
+    private FeedbackController feedbackController;
+
+    Long nonexistentFeedbackId = 9990009999L;
+    Long existentFeedbackId = 1L;
+
+    @Test
+    void whenNonExistentFeedback_thenThrowsException() {
+        UsernamePasswordAuthenticationToken principal = this.getPrincipal("enrique.iglesias@email.com");
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            feedbackController.getFeedbacks(principal, model, nonexistentFeedbackId);
+        });
+    }
+
+    @Test
+    void whenExistentFeedback_thenThrowsException() {
+        UsernamePasswordAuthenticationToken principal = this.getPrincipal("enrique.iglesias@email.com");
+        Assertions.assertEquals(feedbackController.feedbackListQuestionTemplate,
+                feedbackController.getFeedbacks(principal, model, existentFeedbackId));
+    }
+
+    protected UsernamePasswordAuthenticationToken getPrincipal(String username) {
+        // src from: https://stackoverflow.com/q/15203485/7362660
+        UserDetails user = myUserDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(
+                user,
+                user.getPassword(),
+                user.getAuthorities());
+    }
+}

--- a/src/test/java/dev/drugowick/threehundredsixty/controller/profile/PasswordChangeControllerIntegrationTest.java
+++ b/src/test/java/dev/drugowick/threehundredsixty/controller/profile/PasswordChangeControllerIntegrationTest.java
@@ -21,7 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
-class PasswordChangeControllerTest {
+class PasswordChangeControllerIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
@brunodrugowick , esse PR tem testes para o FeedbackController.

Dessa vez, fiz os testes integrados do controlador (`mockMvc.perform()`), e também testes unitários (`assertEquals` e `assertThrows`); apesar de pequenos, cada um em um arquivo, porque há diferença nos imports e porque conceitualmente são coisas diferentes.

Nessa linha, por isso, renomeei o antigo test-case.

Também deixei o nome do template como um atributo `private` da classe, porque, esse valor seria usado no test unitário para saber se foi bem sucedido; e assim fica centralizado, pode mudar o nome do template sem quebrar o teste. Coisa que não aconteceria se copiasse e colasse o mesmo nome, simplesmente.

Além disso, fiquei com a impressão de que lançar uma `RuntimeException` genérica (feedbacks não encontrados) é pior para testar do que usar `@ControllerAdvice` para capturar elas. Porque, do ponto de vista do teste de integração, não tem muita informação sobre o erro. 
Nesse PR eu uso `.andExpect(status().is5xxServerError())` mas isso poderia ser qualquer coisa, até um template-not-found; daí então, tive vontade de escrever um teste mais granular, e saiu os units tests.

Me diz o que você acha! \o/