### PR TITLE
Script to build (with retry)

### DIFF
--- a/.github/workflows/master_feedback-center.yml
+++ b/.github/workflows/master_feedback-center.yml
@@ -21,7 +21,7 @@ jobs:
         java-version: '11'
 
     - name: Build with Maven
-      run: mvn clean install
+      run: bash mvn_clean_install.sh
 
     - name: Deploy to Azure Web App
       uses: azure/webapps-deploy@v1

--- a/mvn_clean_install.sh
+++ b/mvn_clean_install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+##
+# This script runs maven and try to hadle exceptions when jacoco generate report
+
+##
+# for flag 'rerunFailingTestsCount' 
+#	see: https://maven.apache.org/surefire/maven-failsafe-plugin/examples/rerun-failing-tests.html
+
+mvn -Dfailsafe.rerunFailingTestsCount=3 clean install
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+    echo "=== Running simple retry for exception when generating jacoco report :|"
+    mvn -Dfailsafe.rerunFailingTestsCount=3 clean install
+fi


### PR DESCRIPTION
@brunodrugowick esse PR é uma sugestão como como resolver o problema (discutido [aqui](https://github.com/brunodrugowick/three-hundred-sixty-poc/pull/48#issuecomment-637773203)) de, as vezes, a build falhar porque o Jacoco não conseguiu salvar o report dele. Sendo que, rodar novamente resolve.

Para isso, criei um script que builda (e faz retry se precisar) e chamo ele, invés de chamar diretamente o mvn.

Preciso de ajudar: 
para testar se isso funciona mesmo (ou se ao menos não quebrar o que já funciona :smile:)