### PR TITLE
Extra tests employee admin controller

### DIFF
--- a/src/test/java/dev/drugowick/threehundredsixty/controller/admin/EmployeeAdminControllerTest.java
+++ b/src/test/java/dev/drugowick/threehundredsixty/controller/admin/EmployeeAdminControllerTest.java
@@ -1,0 +1,160 @@
+package dev.drugowick.threehundredsixty.controller.admin;
+
+import org.junit.FixMethodOrder;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Random;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class EmployeeAdminControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    /**
+     * This rand is used to bypass a problem[1] with few tests functions.
+     * These functions run individually, everything goes just fine;
+     * on the other hand, if all class' method were run, the exception is throw again.
+     *
+     * [1]:
+     *  org.springframework.dao.DataIntegrityViolationException
+     */
+    private Random rand = new Random();
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password", roles = {"USER"})
+    void givenUserWithRoleUserOnly_whenGetList_thenBlock() throws Exception {
+        mockMvc.perform(get("/admin/employees")
+                .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password", roles = {"USER", "ADMIN"})
+    void givenUserWithRoleUserAdmin_whenGetList_thenOk() throws Exception {
+        mockMvc.perform(get("/admin/employees")
+                .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password", roles = {"USER", "ADMIN"})
+    void givenUserWithRoleUserAdmin_whenGetEmployeeById_thenOk() throws Exception {
+        mockMvc.perform(get("/admin/employees/1")
+                .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password", roles = {"USER", "ADMIN"})
+    void givenUserWithRoleUserAdmin_whenPostEmployeeById_thenFail() throws Exception {
+        mockMvc.perform(post("/admin/employees/1")
+                .with(csrf())
+                .param("email", "some.valid.email@email.com")
+        )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("admin/employee-edit"))
+                .andExpect(MockMvcResultMatchers.model().attributeHasFieldErrors("employee", "name", "position", "roles")); // only fields with validator and failed
+    }
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password", roles = {"USER", "ADMIN"})
+    void givenUserWithRoleUserAdmin_whenPostEmployeeById_thenOk() throws Exception {
+        mockMvc.perform(post("/admin/employees/1")
+                .with(csrf())
+                .param("name", "John Foo")
+                .param("position", "Analista de Sistemas")
+                .param("email", "some.valid.email@email.com")
+                .param("roles", "ROLE_USER,ROLE_ADMIN")
+        )
+                .andDo(print())
+                .andExpect(status().isFound())
+                .andExpect(MockMvcResultMatchers.view().name("redirect:/admin/employees"))
+                .andExpect(MockMvcResultMatchers.model().hasNoErrors())
+                .andExpect(MockMvcResultMatchers.model().errorCount(0));
+    }// ¿are this test, the test-killer?
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password", roles = {"USER", "ADMIN"})
+    void givenUserWithRoleUserAdmin_whenGetNewEmployeePage_thenOk() throws Exception {
+        mockMvc.perform(get("/admin/employees/new")
+                .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password", roles = {"USER", "ADMIN"})
+    void givenUserWithRoleUserAdmin_whenPostNewEmployeePage_thenOk() throws Exception {
+        mockMvc.perform(post("/admin/employees/new")
+                .with(csrf())
+                .param("name", "John Foo" + rand.nextInt())
+                .param("position", "Analista de Sistemas")
+                .param("email", "some.valid.email." +  + rand.nextInt() +"@email.com")
+                .param("roles", "ROLE_USER,ROLE_ADMIN")
+        )
+                .andDo(print())
+                .andExpect(status().isFound())
+                .andExpect(MockMvcResultMatchers.view().name("redirect:/admin/employees"))
+                .andExpect(MockMvcResultMatchers.model().hasNoErrors())
+                .andExpect(MockMvcResultMatchers.model().errorCount(0));
+    }
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password", roles = {"USER", "ADMIN"})
+    void givenUserWithRoleUserAdmin_whenPostNewEmployeePage_thenFail() throws Exception {
+        mockMvc.perform(post("/admin/employees/new")
+                .with(csrf())
+                .param("name", "John Foo")
+                .param("position", "Analista de Sistemas")
+                .param("email", "@email.com")
+                .param("roles", "")
+        )
+                .andDo(print())
+                .andExpect(status().is(200))
+                .andExpect(MockMvcResultMatchers.view().name("admin/employee-edit"))
+                .andExpect(MockMvcResultMatchers.model().errorCount(2))
+                .andExpect(MockMvcResultMatchers.model().attributeHasFieldErrors("employee", "email", "roles"));
+    }
+
+    private void testToggle() throws Exception {
+        mockMvc.perform(post("/admin/employees")
+                .with(csrf())
+                .param("id", "1")
+        )
+                .andDo(print())
+                .andExpect(status().isFound())
+                .andExpect(MockMvcResultMatchers.view().name("redirect:/admin/employees"))
+                .andExpect(MockMvcResultMatchers.model().hasNoErrors())
+                .andExpect(MockMvcResultMatchers.model().errorCount(0));
+    }
+
+    @Test
+    @WithMockUser(username = "enrique.iglesias@email.com", password = "password", roles = {"USER", "ADMIN"})
+    void givenUserWithRoleUserAdmin_whenPostToggleEmployee_thenOk() throws Exception {
+        // called 2x to actually test toggle behaviour
+        testToggle();
+        testToggle();
+    }
+}


### PR DESCRIPTION
@brunodrugowick , esse PR poem alguns testes para o `EmployeeAdminController`, naquele esquema de sempre :joy: 

As novidades desta vez foram:
* ao contrário do que eu achava até então, precisei passar explicitamente `roles = {"USER", "ADMIN"}` para não ser bloqueado ao enviar a request
    * particulamente, esperava mais automação do Spring pra isso, achei muito trabalhoso descobrir isso e precisar deixar explicito. Achava que ele buscava esse usuário e usava ele para o teste, aparentemente não é exatamente assim (claro, pode ser trabalhoso por eu não estar usando 100% certo, mas vou seguir).
* enquanto eu fazia as funções e testavam individualmente, tudo bem. Mas ao rodar os métodos pela botão da classe, tive um `DataIntegrityViolationException` entre as funções que testavam os endpoints `/admin/employees/new` e `/admin/employees/1`. Aí, pra deixar bem idempotente, eu acrescentei um numero rand no nome/email. Mas, aparentemente, o ambiente de testes só é destruído depois de rodar os testes da classe, não a cada método.
     * não parei para refletir se isso refletiria um problema real na API, a primeira vista é "bem básico" para não ter sido pego com o uso local e no heroku, então, deve ser algo too-technical.. Me diz o que você acha...
* por causa desse problema, reparei que não sabia o critério que o Spring usava para escolher a sequencia dos testes, então, deixei um critério explicitado só para demonstrar, e fugir um pouco do convension-over-configuration :) hahaha 