### PR TITLE
Skip JaCoCo when skipping tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,9 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.5</version>
+                <configuration>
+                    <skip>${skipTests}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Should skip JaCoCo things when tests are being skipped.

Fixes Heroku build that fails to write JaCoCo report, by completely skipping JaCoCo things when building in Heroku (which happens with the command `./mvnw -DskipTests clean dependency:list install`).